### PR TITLE
Fix issue with layout of label and CKEDITOR in Firefox and IE.

### DIFF
--- a/ckeditor/static/ckeditor/init.js
+++ b/ckeditor/static/ckeditor/init.js
@@ -40,6 +40,9 @@ window.Django_CKEditor_Configs = [];
                         }
                     });
 
+                    // Fix issue with layout of label and CKEDITOR in Firefox and IE
+                    django.jQuery(el).before('<br/><br/>');
+                    
                     CKEDITOR.replace(elid, config);
                     done.push(elid);
                 }


### PR DESCRIPTION
I found that on Firefox (and possibly IE, but not confirmed), the label on the Django admin forms run into the top of the CKEditor box. I couldn't get any CSS fixes on the CKEditor to fix this, but a couple <br> after the label does. It is a bit hacky, but it works well.
